### PR TITLE
feature:(dev/backend): added complete reflection-question  endpoint

### DIFF
--- a/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/controller/EntitiController.java
+++ b/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/controller/EntitiController.java
@@ -306,7 +306,7 @@ public class EntitiController {
     }
 
 
-    /********************************** TASK COMPLETE *****************/
+    /********************************** COMPLETE ENTITIES*****************/
     @ApiOperation(value = "Complete a task.")
     @PutMapping("/complete/{task_id}/{rating}")
     public MessageResponse completeTask(@PathVariable @ApiParam(value = "Id of the task.", example = "5") Long task_id, @PathVariable @ApiParam(value = "Rating of the task.", example = "5") Long rating) {
@@ -318,4 +318,17 @@ public class EntitiController {
     public MessageResponse completeRoutine(@PathVariable @ApiParam(value = "Id of the routine.", example = "5") Long routine_id, @PathVariable @ApiParam(value = "Rating of the routine.", example = "5") Long rating) {
         return entitiService.completeRoutine(routine_id, rating);
     }
+
+    @ApiOperation(value = "Complete a question.")
+    @PutMapping("/complete/{question_id}")
+    public MessageResponse completeQuestion(@PathVariable @ApiParam(value = "Id of the task.", example = "5") Long question_id) {
+        return entitiService.completeQuestion(question_id);
+    }
+
+    @ApiOperation(value = "Complete a reflection.")
+    @PutMapping("/complete/{reflection_id}")
+    public MessageResponse completeRefection(@PathVariable @ApiParam(value = "Id of the reflection.", example = "5") Long reflection_id) {
+        return entitiService.completeRefection(reflection_id);
+    }
+
 }

--- a/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/service/EntitiService.java
+++ b/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/service/EntitiService.java
@@ -694,4 +694,19 @@ public class EntitiService {
         return new MessageResponse("This deadline evaluated successfully, move on to next deadline!",MessageType.SUCCESS);
     }
 
+    public MessageResponse completeQuestion(Long question_id) {
+        Question question_from_db = questionRepository.findById(question_id).orElseThrow(()-> new ResponseStatusException(HttpStatus.NOT_FOUND, "Question not found!"));
+        question_from_db.setCompletedAt(new Date(System.currentTimeMillis()));
+        question_from_db.setIsDone(Boolean.TRUE);
+        questionRepository.save(question_from_db);
+        return new MessageResponse("Question completed !",MessageType.SUCCESS);
+
+    }
+
+    public MessageResponse completeRefection(Long reflection_id) {
+        Reflection reflection_from_db = reflectionRepository.findById(reflection_id).orElseThrow(()-> new ResponseStatusException(HttpStatus.NOT_FOUND, "Reflection not found!"));
+        reflection_from_db.setCompletedAt(new Date(System.currentTimeMillis()));
+        reflection_from_db.setIsDone(Boolean.TRUE);
+        reflectionRepository.save(reflection_from_db);
+        return new MessageResponse("Reflection completed !",MessageType.SUCCESS);}
 }


### PR DESCRIPTION
* I though PUT endpoints on entities cover completing them. 
* They did cover actually, before we introduced new DTO's such as RoutineGetDTO, ReflectionPostDTO.
* We removed isDone field from these DTO's, therefore clientside couldn't complete entities on those PUT endpoints. 
* These new endpoint solves that problem.