### PR TITLE
Frontend/entity new updates

### DIFF
--- a/application/frontend/src/App.tsx
+++ b/application/frontend/src/App.tsx
@@ -99,8 +99,8 @@ export default class App extends React.Component<IAppProps, IAppState> {
                   <CalendarPage />
                 </Route>
                 <Route path="/addEntity/:parentType/:entitiType/:parent_id" children={<AddEntity /> } />
-                <Route path="/editEntity/:entitiType/:entity_id" children={<EditEntity /> } />
-                <Route path="/linkEntityfrom/:goal_id/:entity_id" children={<LinkEntity /> } />
+                <Route path="/editEntity/:parentType/:entitiType/:parent_id/:entity_id" children={<EditEntity /> } />
+                <Route path="/linkEntityfrom/:entitiType/:entity_id" children={<LinkEntity /> } />
                 <Route path="/entity/:entitiType/:entity_id" children={<EntityPage />} />
                 <Route path="/resources/:resource_id" children={<ResourcePage /> } />
                 <Route exact path="/goals/:goal_id" children={<GoalPage goalType={GoalTypes.Normal}/>} />

--- a/application/frontend/src/components/EntityForm.tsx
+++ b/application/frontend/src/components/EntityForm.tsx
@@ -15,11 +15,13 @@ export const EntityForm = (onFinish: ((values: any) => void) | undefined,
     const dateFormat = 'YYYY/MM/DD';
 
     let urlElements = window.location.href.split('/')
+    
     let page = urlElements[3];
     let parentType = urlElements[4];
-    let entitiType = urlElements[5];
+    let entitiType = urlElements[5].toLowerCase();
     let parent_id = urlElements[6]; //it is entity_id if edit entity will used
-    let entity_id= urlElements[3]
+    let entity_id= urlElements[7]
+
     console.log(urlElements)
 
     
@@ -37,14 +39,14 @@ export const EntityForm = (onFinish: ((values: any) => void) | undefined,
             initialValues={{ remember: true }}
             onFinish={onFinish}
         >
-            <h2>{capitalize(entitiType)} Title</h2>
+            <h2>{capitalize(entitiType.toLowerCase())} Title</h2>
             <Form.Item
                 name="title"
                 rules={[{ required: true, message: 'Please input Entity Title!' }]}
             >
                 <Input placeholder="Entity Name" defaultValue={title}/>
             </Form.Item>
-            <h2>{capitalize(entitiType)} Description</h2>
+            <h2>{capitalize(entitiType.toLowerCase())} Description</h2>
             <Form.Item
                 name="description"
                 rules={[{ required: true, message: 'Please input your Entity Description!' }]}
@@ -53,7 +55,7 @@ export const EntityForm = (onFinish: ((values: any) => void) | undefined,
             </Form.Item>
           { (entitiType == "task" || entitiType == "routine") && 
           (<div>
-            <h2>{capitalize(entitiType)} Deadline</h2>
+            <h2>{capitalize(entitiType.toLowerCase())} Deadline</h2>
             <Form.Item
                 name="deadline"
                 rules={[{ required: true, message: 'Please input your Entity Description!' }]}

--- a/application/frontend/src/pages/AddEntity.tsx
+++ b/application/frontend/src/pages/AddEntity.tsx
@@ -43,6 +43,13 @@ export function AddEntity() {
                 </button>
             </Link>
             }
+            {parentType == "groupgoal" &&
+            <Link to={"/groupgoals/" + parent_id} >
+                <button type="button">
+                    Return to Group-Goal
+                </button>
+            </Link>
+            }
             {parentType == "subgoal" &&
             <Link to={"/subgoal/" + parent_id} >
                 <button type="button">
@@ -54,7 +61,7 @@ export function AddEntity() {
              || parentType == "task" || parentType == "routine") &&
             <Link to={`/entity/${parentType}/${parent_id}/` + parent_id} >
                 <button type="button">
-                    Return to SubGoal
+                    Return to {parentType}
                 </button>
             </Link>
             }

--- a/application/frontend/src/pages/AddEntity.tsx
+++ b/application/frontend/src/pages/AddEntity.tsx
@@ -16,9 +16,8 @@ export function AddEntity() {
     console.log(parentType);
     
     const onFinish = (values: any) => {
-        console.log('Received values of form: ', parent_id);
-        values['parent_id'] = parseInt(parent_id) //for now, it adds entity to a goal
-        values['parentType'] = parentType.toUpperCase()
+        values['goalId'] = parseInt(parent_id) //for now, it adds entity to a goal
+        values['goalType'] = parentType.toUpperCase()
         if(entitiType=="QUESTION" || entitiType=="TASK"){
         values["deadline"]=values["deadline"].toDate()
         }
@@ -38,7 +37,7 @@ export function AddEntity() {
         <div>
             {form}
             {parentType == "goal" &&
-            <Link to={"/goal/" + parent_id} >
+            <Link to={"/goals/" + parent_id} >
                 <button type="button">
                     Return to Goal
                 </button>

--- a/application/frontend/src/pages/Dashboard.tsx
+++ b/application/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,189 @@
+import * as React from "react";
+import { Card, Col, Row, Statistic } from "antd";
+import { AimOutlined, StockOutlined } from "@ant-design/icons";
+import axios from "axios";
+
+const user_id = localStorage.getItem("user_id");
+const token = localStorage.getItem("token");
+
+type UserAnalytics = {
+  activeGoalCount: number;
+  averageCompletionTimeOfGoals: number;
+  averageExtensionCount: number;
+  averageRating: number;
+  completedGoalCount: number;
+  bestGoal: {
+    description: string;
+    id: number;
+    title: string;
+  } | null;
+  longestGoal: {
+    description: string;
+    id: number;
+    title: string;
+  } | null;
+  shortestGoal: {
+    description: string;
+    id: number;
+    title: string;
+  } | null;
+  worstGoal: {
+    description: string;
+    id: number;
+    title: string;
+  } | null;
+};
+
+const initialAnalytics: UserAnalytics = {
+  activeGoalCount: 0,
+  averageCompletionTimeOfGoals: 0,
+  averageExtensionCount: 0,
+  averageRating: 0,
+  bestGoal: null,
+  completedGoalCount: 0,
+  longestGoal: null,
+  shortestGoal: null,
+  worstGoal: null,
+};
+export interface IDashboardProps {}
+
+export function Dashboard(props: IDashboardProps) {
+  const { Meta } = Card;
+  const [analyticsData, setAnalyticsData] = React.useState(initialAnalytics);
+
+  React.useEffect(() => {
+    axios
+      .get(`/users/analytics/${user_id}`, {
+        headers: { Authorization: `Bearer ${token}` },
+        data: {},
+      })
+      .then((response) => {
+        // check for error response
+        if (response.status === 200) {
+          setAnalyticsData(response.data);
+        }
+      })
+      .catch((error) => {
+        console.error("There was an error!", error);
+      });
+  }, [analyticsData]);
+  return (
+    <div className="site-card-wrapper">
+      <Row gutter={[16, 32]}>
+        <Col span={24} style={{ textAlign: "center" }}>
+          <Card bordered={false} title="Completed Goals">
+            <Statistic value={analyticsData.completedGoalCount} />
+          </Card>
+        </Col>
+        <Col span={6}>
+          <Card bordered={false}>
+            <Meta
+              avatar={<AimOutlined />}
+              title="Best Goal"
+              description={
+                analyticsData.bestGoal ? (
+                  <div>
+                    <h3>{analyticsData.bestGoal.title}</h3>
+                    <p>{analyticsData.bestGoal.description}</p>
+                  </div>
+                ) : (
+                  "N/A"
+                )
+              }
+            />
+          </Card>
+        </Col>
+        <Col span={6}>
+          <Card bordered={false}>
+            <Meta
+              avatar={<AimOutlined />}
+              title="Longest Goal"
+              description={
+                analyticsData.longestGoal ? (
+                  <div>
+                    <h3>{analyticsData.longestGoal.title}</h3>
+                    <p>{analyticsData.longestGoal.description}</p>
+                  </div>
+                ) : (
+                  "N/A"
+                )
+              }
+            />
+          </Card>
+        </Col>
+        <Col span={6}>
+          <Card bordered={false}>
+            <Meta
+              avatar={<AimOutlined />}
+              title="Shortest Goal"
+              description={
+                analyticsData.shortestGoal ? (
+                  <div>
+                    <h3>{analyticsData.shortestGoal.title}</h3>
+                    <p>{analyticsData.shortestGoal.description}</p>
+                  </div>
+                ) : (
+                  "N/A"
+                )
+              }
+            />
+          </Card>
+        </Col>
+        <Col span={6}>
+          <Card bordered={false}>
+            <Meta
+              avatar={<AimOutlined />}
+              title="Worst Goal"
+              description={
+                analyticsData.worstGoal ? (
+                  <div>
+                    <h3>{analyticsData.worstGoal.title}</h3>
+                    <p>{analyticsData.worstGoal.description}</p>
+                  </div>
+                ) : (
+                  "N/A"
+                )
+              }
+            />
+          </Card>
+        </Col>
+        <Col span={6}>
+          <Card bordered={false}>
+            <Meta
+              avatar={<StockOutlined />}
+              title="Average Completion Time"
+              description={analyticsData.averageCompletionTimeOfGoals ? analyticsData.averageCompletionTimeOfGoals : 'N/A'}
+            />
+          </Card>
+        </Col>
+        <Col span={6}>
+          <Card bordered={false}>
+            <Meta
+              avatar={<StockOutlined />}
+              title="Active Goals"
+              description={analyticsData.activeGoalCount ? analyticsData.activeGoalCount : 'N/A'}
+            />
+          </Card>
+        </Col>
+        <Col span={6}>
+          <Card bordered={false}>
+            <Meta
+              avatar={<StockOutlined />}
+              title="Average Rating"
+              description={analyticsData.averageRating ? analyticsData.averageRating : 'N/A'}
+            />
+          </Card>
+        </Col>
+        <Col span={6}>
+          <Card bordered={false}>
+            <Meta
+              avatar={<StockOutlined />}
+              title="Average Extension Count"
+              description={analyticsData.averageExtensionCount ? analyticsData.averageExtensionCount : 'N/A'}
+            />
+          </Card>
+        </Col>
+      </Row>
+    </div>
+  );
+}

--- a/application/frontend/src/pages/EditEntity.tsx
+++ b/application/frontend/src/pages/EditEntity.tsx
@@ -10,6 +10,13 @@ const token = localStorage.getItem("token")
 
 export function EditEntity() {
 
+    let urlElements = window.location.href.split('/')
+    
+    let page = urlElements[3];
+    let parentType = urlElements[4];
+    let entitiType2 = urlElements[5].toLowerCase();
+    let parent_id = urlElements[6]; //it is entity_id if edit entity will used
+    let entity_id2= urlElements[7]
 
 
     const onFinish = (values: any) => {
@@ -36,8 +43,8 @@ export function EditEntity() {
                 .then(() => setAdded(true)) 
         })
   //id lazım
-
     };
+
 
     const [isAdded, setAdded] = useState(false)
     const [isLoaded, setLoaded] = useState(false)
@@ -80,14 +87,37 @@ export function EditEntity() {
         message = <h2>Goal Edited Successfully!</h2>
     }
     return (
-
         <div>
             {form}
-            <Link to="/goals">
+            {parentType == "goal" &&
+            <Link to={"/goals/" + parent_id} >
                 <button type="button">
-                    Return to Goals
+                    Return to Goal
                 </button>
             </Link>
+            }
+            {parentType == "groupgoal" &&
+            <Link to={"/groupgoals/" + parent_id} >
+                <button type="button">
+                    Return to Group-Goal
+                </button>
+            </Link>
+            }
+            {parentType == "subgoal" &&
+            <Link to={"/subgoal/" + parent_id} >
+                <button type="button">
+                    Return to SubGoal
+                </button>
+            </Link>
+            }
+            {(parentType == "question" || parentType == "reflection"
+             || parentType == "task" || parentType == "routine") &&
+            <Link to={`/entity/${parentType}/${parent_id}/` + parent_id} >
+                <button type="button">
+                    Return to {parentType}
+                </button>
+            </Link>
+            }
             {message}
         </div>
 

--- a/application/frontend/src/pages/EntityPage.tsx
+++ b/application/frontend/src/pages/EntityPage.tsx
@@ -226,7 +226,7 @@ export function EntityPage() {
             <h2>Linked Entities:</h2>
             <Table columns={columns} dataSource={entities} />
             <br></br>
-            <Link to={"/linkEntityfrom/" +goal_id+ "/"+ entity_id}> 
+            <Link to={"/linkEntityfrom/" +entitiType.toLowerCase()+ "/"+ entity_id}> 
                 <button type="button">
                     Link Entity
                 </button>

--- a/application/frontend/src/pages/EntityPage.tsx
+++ b/application/frontend/src/pages/EntityPage.tsx
@@ -156,27 +156,26 @@ export function EntityPage() {
             })
             .then(data => {
                 let tmp = []
-                let sublinks=data.sublinks
+                let sublinked_entities=data.sublinked_entities
                 console.log("data:" + JSON.stringify(data))
                 if(entitiType.toLowerCase() =="task" || entitiType.toLowerCase() =="routine"  ){
                     setDeadline(data.deadline)
                     console.log(data.deadline)
                 }
-                if(sublinks!==null){
-                for (let i = 0; i < sublinks.length; i++) {
-                    console.log(sublinks)
+                
+                for (let i = 0; i < sublinked_entities.length; i++) {
+                    console.log(sublinked_entities)
                     tmp.push({
-                        key: sublinks[i]['id'],
-                        title: sublinks[i]['title'],
-                        description: sublinks[i]['description'],
-                        entityType: sublinks[i]['entitiType'],
+                        key: sublinked_entities[i]['id'],
+                        title: sublinked_entities[i]['title'],
+                        description: sublinked_entities[i]['description'],
+                        entityType: sublinked_entities[i]['entitiType'],
                         //isDone: sublinks[i]['isDone'],
                         //period: sublinks[i]['period'],
                         //rating: sublinks[i]['rating'],
                         //deadline: sublinks[i]['deadline']
                     })
                 }
-            }
                 // @ts-ignore
                 setEntities(tmp)
                 setLoaded(true)

--- a/application/frontend/src/pages/EntityPage.tsx
+++ b/application/frontend/src/pages/EntityPage.tsx
@@ -162,7 +162,7 @@ export function EntityPage() {
                     setDeadline(data.deadline)
                     console.log(data.deadline)
                 }
-                
+                if(sublinks!==null){
                 for (let i = 0; i < sublinks.length; i++) {
                     console.log(sublinks)
                     tmp.push({
@@ -176,6 +176,7 @@ export function EntityPage() {
                         //deadline: sublinks[i]['deadline']
                     })
                 }
+            }
                 // @ts-ignore
                 setEntities(tmp)
                 setLoaded(true)

--- a/application/frontend/src/pages/EntityPage.tsx
+++ b/application/frontend/src/pages/EntityPage.tsx
@@ -121,11 +121,14 @@ export function EntityPage() {
 
     const deleteLink = (entity: { key: any}) => {
         console.log('Received values of delete: ', entity);
-        axios.delete(`/entities/${entity_id}/delete_link/${entity.key}`,
+        var values = { childId: "", childType: "ENTITI" }
+        values.childId = entity.key
+        axios.delete(`/entities/${entity_id}/link/`,
             {
                 headers: { Authorization: `Bearer ${token}`},
-                data: {}
+                data: values
             }).then(() => getEntities())
+            
     };
 
     const deleteResource = (resource: { key: any,id:number}) => {

--- a/application/frontend/src/pages/GoalPage.tsx
+++ b/application/frontend/src/pages/GoalPage.tsx
@@ -183,7 +183,7 @@ const columns = [
                             Delete
                         </Button>
                     </Space>
-                    <Link to={"/editEntity/" + entity.entitiType + "/" + entity.id}>
+                    <Link to={"/editEntity/" + goalType.substring(0, goalType.length - 1) +"/" +entity.entitiType + "/" +goal_id+ "/"+ entity.id}>
                         <button type="button">
                             Edit
                         </button>

--- a/application/frontend/src/pages/LinkEntity.tsx
+++ b/application/frontend/src/pages/LinkEntity.tsx
@@ -4,19 +4,36 @@ import {useEffect, useState} from "react";
 import axios from "axios";
 import {Link} from "react-router-dom";
 import {Table,Space,Button} from "antd";
+import { url } from "inspector";
 
 const token = localStorage.getItem("token")
 
 export function LinkEntity() {
     const [possible_entities, setEntities] = useState([])
+    const[possible_sugoals ,setPossibleSubGoals]=useState([])
+    const[goal_type,setGoalType]=useState("")
+    const[goal_id,setGoalId]=useState(null)
+    const[groupgoal_id,setGroupGoalId]=useState(null)
+  
 
 
     const linkEntities = (target_entity:any) => {
-        console.log('Received values of delete: ', target_entity);
-        axios.post(`/entities/${entity_id}/link/${target_entity.id}`,
+        let urlElements = window.location.href.split('/')
+        let page = urlElements[3];
+        let entitiType=urlElements[4];
+        let entity_id =urlElements[5];
+
+        console.log("target:" +target_entity.entitiType)
+        console.log(urlElements)
+        console.log("entity id: " + entity_id)
+        console.log('Received values of delete: ', typeof(JSON.stringify(target_entity)));
+        var values = {childId: "", childType: ""}
+        values.childId=target_entity.id
+        values.childType=target_entity.entitiType
+        console.log("values: " + JSON.stringify(values))
+        axios.post(`/entities/${entity_id}/link`,values,
             {
                 headers: { Authorization: `Bearer ${token}`},
-                data: {}
             })
     };
 
@@ -45,7 +62,7 @@ export function LinkEntity() {
             title: 'Link',
             key: 'id',
             render: (text: any,
-                     entity: { key:any}) =>
+                     entity: { key:any, entitiType:any}) =>
                 (   <div>
                         <Space size="middle">
                             <Button type="primary" onClick={() => linkEntities(entity)}>
@@ -62,14 +79,51 @@ export function LinkEntity() {
     const [isSubmitted, setSubmitted] = useState(false)
     // @ts-ignore
 
-    const {goal_id, entity_id} = useParams();
-
-
-
     useEffect(() => {
         //to get the user id
-        console.log("user-id: "+user_id)
-        axios.get(`/entities/groupgoal/${goal_id}`,
+        let urlElements = window.location.href.split('/')
+        let page = urlElements[3];
+        let entitiType=urlElements[4];
+        let entity_id =urlElements[5];
+        console.log(urlElements)
+        console.log("entity id: " + entity_id)
+    
+        axios.get(`/entities/${entitiType}/${entity_id}`,
+            {
+                headers: { Authorization: `Bearer ${token}`},
+                data: {}
+            })
+            .then(response => {
+                // check for error response
+                if (response.status === 200) {
+                    return response.data
+                }
+                throw response
+            })
+            .then(data => {
+                if(data.goal_id!==null){
+                    setGoalType("goal")
+                    setGoalId(data.goal_id)
+                    console.log(data.goal_id)
+                    console.log(data.goal_id)
+                }
+                else{
+                    setGoalType("groupgoal")
+                    setGroupGoalId(data.groupgoal_id)
+                }
+                console.log(goal_type)
+            })
+            .catch(error => {
+                console.error('There was an error!', error);
+            });
+
+
+        console.log(urlElements)
+        console.log("entity id: " + entity_id)
+        //get all possible entities
+
+
+        goal_type!=="" && axios.get(`/entities/${goal_type}/${goal_id}`,
             {
                 headers: { Authorization: `Bearer ${token}`},
                 data: {}
@@ -102,7 +156,42 @@ export function LinkEntity() {
             .catch(error => {
                 console.error('There was an error!', error);
             });
-    }, []);
+            //get all possible subgoals
+            axios.get(`/subgoals/of_user/${user_id}`,
+            {
+                headers: { Authorization: `Bearer ${token}`},
+                data: {}
+            })
+            .then(response => {
+                // check for error response
+                if (response.status === 200) {
+                    return response.data
+                }
+                throw response
+            })
+            .then(data => {
+                
+                let tmp = []
+                console.log(data);
+                for (let i = 0; i < data.length; i++) {
+                    if(data[i].id!=entity_id){
+                    tmp.push({
+                        id: data[i]['id'],
+                        title: data[i]['title'],
+                        description: data[i]['description'],
+                        entityType: "SUB-GOAL",
+                    })
+                }
+                }
+                // @ts-ignore
+                setPossibleSubGoals(tmp)
+
+            })
+            .catch(error => {
+                console.error('There was an error!', error);
+            });
+
+    }, [goal_type,goal_id]);
 
 
     let message;
@@ -113,13 +202,9 @@ export function LinkEntity() {
     return (
 
         <div>
-            <h1>Entitites to Link:</h1>
-            <Table columns={columns} dataSource={possible_entities} />
-            <Link to={"/entity/" + entity_id} >
-                <button type="button">
-                    Return to Entity
-                </button>
-            </Link>
+            <h1>Link to:</h1>
+            <Table columns={columns} dataSource={possible_entities.concat(possible_sugoals)} />
+
             {message}
         </div>
 


### PR DESCRIPTION
At the previous versions,
-users cannot link subgoals to an entity and they are now.
-users cannot create entities under entities and they are now.

Note: there are still some work to nicely handle the creation entity under entities, but for the sake of simplicity, merge will be nice for now. 

Now,
-new structure which can help to keep the entities which are created under an ENTITY is implemented
-new endpoints (link button, showing links, delete links, subgoals) are implemented.
