### PR TITLE
Linking with Goal feature for entities

### DIFF
--- a/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/controller/GroupGoalController.java
+++ b/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/controller/GroupGoalController.java
@@ -9,10 +9,13 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.Example;
 import io.swagger.annotations.ExampleProperty;
 import lombok.RequiredArgsConstructor;
+import org.json.simple.parser.ParseException;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 @CrossOrigin(origins = "http://localhost:8085")
 @RestController
@@ -135,9 +138,27 @@ public class GroupGoalController {
         return groupGoalService.createSubgoal(subgoal_dto);
     }
 
+
     @ApiOperation(value = "Get subgoals of a group goal.")
     @GetMapping("/subgoal/{groupgoal_id}")
     public List<SubgoalGetDTO> getSubgoalsOfGroupGoal(@PathVariable @ApiParam(value = "Id of the group goal.", example = "5") Long groupgoal_id) {
         return groupGoalService.getSubgoalsOfGroupGoal(groupgoal_id);
     }
+
+    @ApiOperation(value = "Add tags to a groupgoal.")
+    @PutMapping("/{groupgoal_id}/tag")
+    public MessageResponse addTags(@PathVariable @ApiParam(value = "Id of the groupgoal.", example = "5") Long groupgoal_id,
+                                   @RequestBody @ApiParam(value = "Set of tags as list.", example = "['tag1','tag2']") Set<String> tags) throws IOException, ParseException
+    {
+        return groupGoalService.addTags(groupgoal_id, tags);
+    }
+
+    @ApiOperation(value = "Remove tags from a groupgoal.")
+    @PutMapping("/{groupgoal_id}/removetag/{tag}")
+    public MessageResponse removeTags(@PathVariable @ApiParam(value = "Id of the groupgoal.", example = "5") Long groupgoal_id,
+                                      @PathVariable @ApiParam(value = "Name of the tag.", example = "5") String tag) throws IOException, ParseException {
+        return groupGoalService.removeTag(groupgoal_id, tag);
+    }
+
+
 }

--- a/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/dto/entities/LinkType.java
+++ b/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/dto/entities/LinkType.java
@@ -3,5 +3,7 @@ package cmpe451.group12.beabee.goalspace.dto.entities;
 public enum LinkType
 {
     ENTITI,
-    SUBGOAL
+    SUBGOAL,
+    GOAL,
+    GROUPGOAL
 }

--- a/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/dto/goals/GoalGetDTO.java
+++ b/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/dto/goals/GoalGetDTO.java
@@ -29,7 +29,7 @@ public class GoalGetDTO {
 
     private Set<SubgoalDTOShort> subgoals;
 
-    private Set<EntitiDTOShort> entities;
+    private Set<EntitiDTOShort> linkedEntities;
     private Set<String> tags;
 
 }

--- a/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/dto/goals/GroupGoalGetDto.java
+++ b/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/dto/goals/GroupGoalGetDto.java
@@ -33,7 +33,7 @@ public class GroupGoalGetDto
 
     private Set<SubgoalDTOShort> subgoals;
 
-    private Set<EntitiDTOShort> entities;
+    private Set<EntitiDTOShort> linkedEntities;
 
     private String token;
 

--- a/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/dto/goals/GroupGoalGetDto.java
+++ b/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/dto/goals/GroupGoalGetDto.java
@@ -38,4 +38,6 @@ public class GroupGoalGetDto
     private String token;
 
     private Set<UserCredentialsGetDTO> members;
+
+    private Set<String> tags;
 }

--- a/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/mapper/goals/GroupGoalPostMapper.java
+++ b/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/mapper/goals/GroupGoalPostMapper.java
@@ -6,16 +6,39 @@ import cmpe451.group12.beabee.goalspace.model.goals.Goal;
 import cmpe451.group12.beabee.goalspace.model.goals.GroupGoal;
 import org.mapstruct.Mapper;
 
+import java.util.ArrayList;
 import java.util.List;
 
-@Mapper(componentModel = "spring")
-public interface GroupGoalPostMapper {
-    GroupGoalPostDTO mapToDto(GroupGoal groupGoal);
+public class GroupGoalPostMapper {
+    //GroupGoalPostDTO mapToDto(GroupGoal groupGoal);
 
-    GroupGoal mapToEntity(GroupGoalPostDTO groupGoalPostDTO);
+    public GroupGoal mapToEntity(GroupGoalPostDTO groupGoalPostDTO)
+    {
+        if ( groupGoalPostDTO == null ) {
+            return null;
+        }
 
-    List<GroupGoalPostDTO> mapToDto(List<GroupGoal> groupGoalList);
+        GroupGoal groupGoal = new GroupGoal();
+        groupGoal.setTitle(groupGoalPostDTO.getTitle());
+        groupGoal.setDescription(groupGoalPostDTO.getDescription());
 
-    List<GroupGoal> mapToEntity(List<GroupGoalPostDTO> goalPostDTOList);
+        return groupGoal;
+    }
+
+    //List<GroupGoalPostDTO> mapToDto(List<GroupGoal> groupGoalList);
+
+    public List<GroupGoal> mapToEntity(List<GroupGoalPostDTO> goalPostDTOList)
+    {
+        if ( goalPostDTOList == null ) {
+            return null;
+        }
+
+        List<GroupGoal> list = new ArrayList<GroupGoal>( goalPostDTOList.size() );
+        for ( GroupGoalPostDTO groupGoalPostDTO : goalPostDTOList ) {
+            list.add( mapToEntity( groupGoalPostDTO ) );
+        }
+
+        return list;
+    }
 
 }

--- a/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/mapper/goals/GroupGoalPostMapper.java
+++ b/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/mapper/goals/GroupGoalPostMapper.java
@@ -1,14 +1,13 @@
 package cmpe451.group12.beabee.goalspace.mapper.goals;
 
-import cmpe451.group12.beabee.goalspace.dto.goals.GoalDTOShort;
 import cmpe451.group12.beabee.goalspace.dto.goals.GroupGoalPostDTO;
-import cmpe451.group12.beabee.goalspace.model.goals.Goal;
 import cmpe451.group12.beabee.goalspace.model.goals.GroupGoal;
-import org.mapstruct.Mapper;
+import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@Component
 public class GroupGoalPostMapper {
     //GroupGoalPostDTO mapToDto(GroupGoal groupGoal);
 

--- a/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/model/entities/Entiti.java
+++ b/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/model/entities/Entiti.java
@@ -76,6 +76,9 @@ public abstract class Entiti {
     @OneToMany(mappedBy = "entiti", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private Set<Resource> resources;
 
+    @Column(name = "isLinkedToGoal")
+    private Boolean isLinkedToGoal;
+
     @Override
     public boolean equals(Object obj)
     {

--- a/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/model/goals/GroupGoal.java
+++ b/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/model/goals/GroupGoal.java
@@ -50,4 +50,20 @@ public class GroupGoal extends AllGoal
     @OneToMany(mappedBy = "mainGroupgoal", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Set<Subgoal> subgoals;
 
+    @ManyToMany
+    @JoinTable(
+            name = "groupgoal_tag",
+            joinColumns = { @JoinColumn(name = "groupgoal_id") },
+            inverseJoinColumns = { @JoinColumn(name = "tag_id") }
+    )
+    private Set<Tag> tags;
+
+    @ManyToMany
+    @JoinTable(
+            name = "groupgoal_hidden_tag",
+            joinColumns = { @JoinColumn(name = "groupgoal_id") },
+            inverseJoinColumns = { @JoinColumn(name = "tag_id") }
+    )
+    private Set<Tag> hiddentags;
+
 }

--- a/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/model/goals/Tag.java
+++ b/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/model/goals/Tag.java
@@ -23,10 +23,17 @@ public class Tag {
     @ManyToMany(mappedBy = "tags")
     private Set<Goal> goals;
 
+    @JsonIgnoreProperties({"tags"})
+    @ManyToMany(mappedBy = "tags")
+    private Set<GroupGoal> group_goals;
+
     @JsonIgnoreProperties({"hiddentags"})
     @ManyToMany(mappedBy = "hiddentags")
     private Set<Goal> goals_of_hidden;
 
+    @JsonIgnoreProperties({"hiddentags"})
+    @ManyToMany(mappedBy = "hiddentags")
+    private Set<GroupGoal> group_goals_of_hidden;
 
     @JsonIgnoreProperties({"tags"})
     @ManyToMany(mappedBy = "tags")

--- a/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/service/EntitiService.java
+++ b/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/service/EntitiService.java
@@ -202,7 +202,6 @@ public class EntitiService {
         }
 
         if (reflectionPostDTO.getInitialLinkType() != null && !(reflectionPostDTO.getInitialParentId() < 0)) {
-            new_reflection.setIsLinkedToGoal(Boolean.FALSE);
             switch (reflectionPostDTO.getInitialLinkType())
             {
                 case ENTITI:
@@ -213,6 +212,7 @@ public class EntitiService {
                         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Parent entity is not in the same group!");
 
                     new_reflection.setCreator(entiti.getCreator());
+                    new_reflection.setIsLinkedToGoal(Boolean.FALSE);
                     Reflection saved_reflection = reflectionRepository.save(new_reflection);
                     entiti.getSublinked_entities().add(saved_reflection);
                     entitiRepository.save(entiti);
@@ -226,6 +226,7 @@ public class EntitiService {
 
                     new_reflection.setSublinked_subgoals(Set.of(subgoal));
                     new_reflection.setCreator(subgoal.getCreator());
+                    new_reflection.setIsLinkedToGoal(Boolean.FALSE);
                     reflectionRepository.save(new_reflection);
                     break;
             }
@@ -258,7 +259,6 @@ public class EntitiService {
         }
 
         if (taskPostDTO.getInitialLinkType() != null && !(taskPostDTO.getInitialParentId() < 0)) {
-            new_task.setIsLinkedToGoal(Boolean.FALSE);
             switch (taskPostDTO.getInitialLinkType())
             {
                 case ENTITI:
@@ -269,6 +269,7 @@ public class EntitiService {
                         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Parent entity is not in the same group!");
 
                     new_task.setCreator(entiti.getCreator());
+                    new_task.setIsLinkedToGoal(Boolean.FALSE);
                     Task saved_task = taskRepository.save(new_task);
                     entiti.getSublinked_entities().add(saved_task);
                     entitiRepository.save(entiti);
@@ -282,6 +283,7 @@ public class EntitiService {
 
                     new_task.setSublinked_subgoals(Set.of(subgoal));
                     new_task.setCreator(subgoal.getCreator());
+                    new_task.setIsLinkedToGoal(Boolean.FALSE);
                     taskRepository.save(new_task);
                     break;
             }
@@ -314,7 +316,6 @@ public class EntitiService {
         }
 
         if (questionPostDTO.getInitialLinkType() != null && !(questionPostDTO.getInitialParentId() < 0)) {
-            new_question.setIsLinkedToGoal(Boolean.FALSE);
             switch (questionPostDTO.getInitialLinkType())
             {
                 case ENTITI:
@@ -325,6 +326,7 @@ public class EntitiService {
                         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Parent entity is not in the same group!");
 
                     new_question.setCreator(entiti.getCreator());
+                    new_question.setIsLinkedToGoal(Boolean.FALSE);
                     Question saved_question = questionRepository.save(new_question);
                     entiti.getSublinked_entities().add(saved_question);
                     entitiRepository.save(saved_question);
@@ -338,6 +340,7 @@ public class EntitiService {
 
                     new_question.setSublinked_subgoals(Set.of(subgoal));
                     new_question.setCreator(subgoal.getCreator());
+                    new_question.setIsLinkedToGoal(Boolean.FALSE);
                     questionRepository.save(new_question);
                     break;
             }
@@ -369,7 +372,6 @@ public class EntitiService {
         }
 
         if (routinePostDTO.getInitialLinkType() != null && !(routinePostDTO.getInitialParentId() < 0)) {
-            new_routine.setIsLinkedToGoal(Boolean.FALSE);
             switch (routinePostDTO.getInitialLinkType())
             {
                 case ENTITI:
@@ -381,6 +383,7 @@ public class EntitiService {
 
                     new_routine.setCreator(entiti.getCreator());
                     new_routine.setSublinked_entities(Set.of(entiti));
+                    new_routine.setIsLinkedToGoal(Boolean.FALSE);
                     Routine saved_routine = routineRepository.save(new_routine);
                     entiti.getSublinked_entities().add(saved_routine);
                     entitiRepository.save(entiti);
@@ -394,6 +397,7 @@ public class EntitiService {
 
                     new_routine.setSublinked_subgoals(Set.of(subgoal));
                     new_routine.setCreator(subgoal.getCreator());
+                    new_routine.setIsLinkedToGoal(Boolean.FALSE);
                     routineRepository.save(new_routine);
                     break;
             }

--- a/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/service/EntitiService.java
+++ b/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/service/EntitiService.java
@@ -11,6 +11,7 @@ import cmpe451.group12.beabee.goalspace.Repository.goals.SubgoalRepository;
 import cmpe451.group12.beabee.goalspace.Repository.resources.ResourceRepository;
 import cmpe451.group12.beabee.goalspace.dto.entities.*;
 import cmpe451.group12.beabee.goalspace.dto.goals.SubgoalDTOShort;
+import cmpe451.group12.beabee.goalspace.dto.goals.SubgoalGetDTO;
 import cmpe451.group12.beabee.goalspace.dto.resources.ResourceDTOShort;
 import cmpe451.group12.beabee.goalspace.enums.EntitiType;
 import cmpe451.group12.beabee.goalspace.mapper.entities.*;
@@ -113,6 +114,14 @@ public class EntitiService {
 
     /****************************** LINKING ENTITIES ********************************/
 
+    private Long parentOfSubgoal(Subgoal subgoal) {
+        if (subgoal.getMainGroupgoal() != null)
+            return subgoal.getMainGroupgoal().getId();
+        else if (subgoal.getMainGoal() != null)
+            return subgoal.getMainGoal().getId();
+        return parentOfSubgoal(subgoalRepository.findParentById(subgoal.getId()));
+    }
+
     public MessageResponse entitiLink(Long id, EntitiLinkDTO entitiLinkDTO) {
         Entiti parentEntiti = entitiRepository.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Parent entity not found"));
@@ -133,7 +142,8 @@ public class EntitiService {
                 Subgoal childSubgoal = subgoalRepository.findById(entitiLinkDTO.getChildId())
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Child subgoal not found"));
 
-                if(parentEntiti.getGoal() != childSubgoal.getMainGoal() || parentEntiti.getGroupgoal() != childSubgoal.getMainGroupgoal())
+                if(!parentEntiti.getGoal().getId().equals(parentOfSubgoal(childSubgoal)) &&
+                        !parentEntiti.getGroupgoal().getId().equals(parentOfSubgoal(childSubgoal)))
                     throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Child subgoal is not in the same group!");
 
                 parentEntiti.getSublinked_subgoals().add(childSubgoal);
@@ -221,12 +231,17 @@ public class EntitiService {
                     Subgoal subgoal = subgoalRepository.findById(reflectionPostDTO.getInitialParentId())
                             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Parent subgoal not found!"));
 
-                    if(new_reflection.getGoal() != subgoal.getMainGoal() || new_reflection.getGroupgoal() != subgoal.getMainGroupgoal())
+                    if(!new_reflection.getGoal().getId().equals(parentOfSubgoal(subgoal)) &&
+                            !new_reflection.getGroupgoal().getId().equals(parentOfSubgoal(subgoal)))
                         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Parent subgoal is not in the same group!");
 
                     new_reflection.setSublinked_subgoals(Set.of(subgoal));
                     new_reflection.setCreator(subgoal.getCreator());
                     new_reflection.setIsLinkedToGoal(Boolean.FALSE);
+                    reflectionRepository.save(new_reflection);
+                    break;
+                case GOAL:
+                case GROUPGOAL:
                     reflectionRepository.save(new_reflection);
                     break;
             }
@@ -278,12 +293,17 @@ public class EntitiService {
                     Subgoal subgoal = subgoalRepository.findById(taskPostDTO.getInitialParentId())
                             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Parent subgoal not found!"));
 
-                    if(new_task.getGoal() != subgoal.getMainGoal() || new_task.getGroupgoal() != subgoal.getMainGroupgoal())
+                    if(!new_task.getGoal().getId().equals(parentOfSubgoal(subgoal)) &&
+                            !new_task.getGroupgoal().getId().equals(parentOfSubgoal(subgoal)))
                         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Parent subgoal is not in the same group!");
 
                     new_task.setSublinked_subgoals(Set.of(subgoal));
                     new_task.setCreator(subgoal.getCreator());
                     new_task.setIsLinkedToGoal(Boolean.FALSE);
+                    taskRepository.save(new_task);
+                    break;
+                case GOAL:
+                case GROUPGOAL:
                     taskRepository.save(new_task);
                     break;
             }
@@ -335,12 +355,17 @@ public class EntitiService {
                     Subgoal subgoal = subgoalRepository.findById(questionPostDTO.getInitialParentId())
                             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Parent subgoal not found!"));
 
-                    if(new_question.getGoal() != subgoal.getMainGoal() || new_question.getGroupgoal() != subgoal.getMainGroupgoal())
+                    if(!new_question.getGoal().getId().equals(parentOfSubgoal(subgoal)) &&
+                            !new_question.getGroupgoal().getId().equals(parentOfSubgoal(subgoal)))
                         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Parent subgoal is not in the same group!");
 
                     new_question.setSublinked_subgoals(Set.of(subgoal));
                     new_question.setCreator(subgoal.getCreator());
                     new_question.setIsLinkedToGoal(Boolean.FALSE);
+                    questionRepository.save(new_question);
+                    break;
+                case GOAL:
+                case GROUPGOAL:
                     questionRepository.save(new_question);
                     break;
             }
@@ -392,12 +417,17 @@ public class EntitiService {
                     Subgoal subgoal = subgoalRepository.findById(routinePostDTO.getInitialParentId())
                             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Parent subgoal not found!"));
 
-                    if(new_routine.getGoal() != subgoal.getMainGoal() || new_routine.getGroupgoal() != subgoal.getMainGroupgoal())
+                    if(!new_routine.getGoal().getId().equals(parentOfSubgoal(subgoal)) &&
+                            !new_routine.getGroupgoal().getId().equals(parentOfSubgoal(subgoal)))
                         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Parent subgoal is not in the same group!");
 
                     new_routine.setSublinked_subgoals(Set.of(subgoal));
                     new_routine.setCreator(subgoal.getCreator());
                     new_routine.setIsLinkedToGoal(Boolean.FALSE);
+                    routineRepository.save(new_routine);
+                    break;
+                case GOAL:
+                case GROUPGOAL:
                     routineRepository.save(new_routine);
                     break;
             }

--- a/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/service/EntitiService.java
+++ b/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/service/EntitiService.java
@@ -138,6 +138,12 @@ public class EntitiService {
 
                 parentEntiti.getSublinked_subgoals().add(childSubgoal);
                 break;
+            case GOAL:
+            case GROUPGOAL:
+                if(parentEntiti.getIsLinkedToGoal())
+                    return new MessageResponse("Already linked to parent", MessageType.ERROR);
+                parentEntiti.setIsLinkedToGoal(Boolean.TRUE);
+                break;
         }
 
         entitiRepository.save(parentEntiti);
@@ -163,6 +169,12 @@ public class EntitiService {
                 if(!parentEntiti.getSublinked_subgoals().removeIf(e -> e.equals(childSubgoal)))
                     return new MessageResponse("Link does not exist", MessageType.ERROR);
                 break;
+            case GOAL:
+            case GROUPGOAL:
+                if(!parentEntiti.getIsLinkedToGoal())
+                    return new MessageResponse("Link does not exist", MessageType.ERROR);
+                parentEntiti.setIsLinkedToGoal(Boolean.FALSE);
+                break;
         }
         entitiRepository.save(parentEntiti);
         return new MessageResponse("Link deleted is successful.", MessageType.SUCCESS);
@@ -174,6 +186,7 @@ public class EntitiService {
         Reflection new_reflection = reflectionPostMapper.mapToEntity(reflectionPostDTO);
         new_reflection.setEntitiType(EntitiType.REFLECTION);
         new_reflection.setIsDone(Boolean.FALSE);
+        new_reflection.setIsLinkedToGoal(Boolean.TRUE);
 
         switch (reflectionPostDTO.getGoalType()) {
             case GOAL:
@@ -188,7 +201,8 @@ public class EntitiService {
                 break;
         }
 
-        if (reflectionPostDTO.getInitialLinkType() != null) {
+        if (reflectionPostDTO.getInitialLinkType() != null && !(reflectionPostDTO.getInitialParentId() < 0)) {
+            new_reflection.setIsLinkedToGoal(Boolean.FALSE);
             switch (reflectionPostDTO.getInitialLinkType())
             {
                 case ENTITI:
@@ -228,6 +242,7 @@ public class EntitiService {
         new_task.setEntitiType(EntitiType.TASK);
         new_task.setIsDone(Boolean.FALSE);
         new_task.setExtension_count(0L);
+        new_task.setIsLinkedToGoal(Boolean.TRUE);
 
         switch (taskPostDTO.getGoalType()) {
             case GOAL:
@@ -242,7 +257,8 @@ public class EntitiService {
                 break;
         }
 
-        if (taskPostDTO.getInitialLinkType() != null) {
+        if (taskPostDTO.getInitialLinkType() != null && !(taskPostDTO.getInitialParentId() < 0)) {
+            new_task.setIsLinkedToGoal(Boolean.FALSE);
             switch (taskPostDTO.getInitialLinkType())
             {
                 case ENTITI:
@@ -281,6 +297,8 @@ public class EntitiService {
         Question new_question = questionPostMapper.mapToEntity(questionPostDTO);
         new_question.setEntitiType(EntitiType.QUESTION);
         new_question.setIsDone(Boolean.FALSE);
+        new_question.setIsLinkedToGoal(Boolean.TRUE);
+
 
         switch (questionPostDTO.getGoalType()) {
             case GOAL:
@@ -295,7 +313,8 @@ public class EntitiService {
                 break;
         }
 
-        if (questionPostDTO.getInitialLinkType() != null) {
+        if (questionPostDTO.getInitialLinkType() != null && !(questionPostDTO.getInitialParentId() < 0)) {
+            new_question.setIsLinkedToGoal(Boolean.FALSE);
             switch (questionPostDTO.getInitialLinkType())
             {
                 case ENTITI:
@@ -334,6 +353,7 @@ public class EntitiService {
         new_routine.setEntitiType(EntitiType.ROUTINE);
         new_routine.setIsDone(Boolean.FALSE);
         new_routine.setExtension_count(0L);
+        new_routine.setIsLinkedToGoal(Boolean.TRUE);
 
         switch (routinePostDTO.getGoalType()) {
             case GOAL:
@@ -348,7 +368,8 @@ public class EntitiService {
                 break;
         }
 
-        if (routinePostDTO.getInitialLinkType() != null) {
+        if (routinePostDTO.getInitialLinkType() != null && !(routinePostDTO.getInitialParentId() < 0)) {
+            new_routine.setIsLinkedToGoal(Boolean.FALSE);
             switch (routinePostDTO.getInitialLinkType())
             {
                 case ENTITI:

--- a/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/service/EntitiService.java
+++ b/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/service/EntitiService.java
@@ -197,6 +197,8 @@ public class EntitiService {
         new_reflection.setEntitiType(EntitiType.REFLECTION);
         new_reflection.setIsDone(Boolean.FALSE);
         new_reflection.setIsLinkedToGoal(Boolean.TRUE);
+        new_reflection.setSublinked_entities(new HashSet<>());
+        new_reflection.setSublinked_subgoals(new HashSet<>());
 
         switch (reflectionPostDTO.getGoalType()) {
             case GOAL:
@@ -235,7 +237,7 @@ public class EntitiService {
                             !new_reflection.getGroupgoal().getId().equals(parentOfSubgoal(subgoal)))
                         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Parent subgoal is not in the same group!");
 
-                    new_reflection.setSublinked_subgoals(Set.of(subgoal));
+                    new_reflection.setSublinked_subgoals(new HashSet<>(Set.of(subgoal)));
                     new_reflection.setCreator(subgoal.getCreator());
                     new_reflection.setIsLinkedToGoal(Boolean.FALSE);
                     reflectionRepository.save(new_reflection);
@@ -259,6 +261,8 @@ public class EntitiService {
         new_task.setIsDone(Boolean.FALSE);
         new_task.setExtension_count(0L);
         new_task.setIsLinkedToGoal(Boolean.TRUE);
+        new_task.setSublinked_entities(new HashSet<>());
+        new_task.setSublinked_subgoals(new HashSet<>());
 
         switch (taskPostDTO.getGoalType()) {
             case GOAL:
@@ -297,7 +301,7 @@ public class EntitiService {
                             !new_task.getGroupgoal().getId().equals(parentOfSubgoal(subgoal)))
                         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Parent subgoal is not in the same group!");
 
-                    new_task.setSublinked_subgoals(Set.of(subgoal));
+                    new_task.setSublinked_subgoals(new HashSet<>(Set.of(subgoal)));
                     new_task.setCreator(subgoal.getCreator());
                     new_task.setIsLinkedToGoal(Boolean.FALSE);
                     taskRepository.save(new_task);
@@ -320,7 +324,8 @@ public class EntitiService {
         new_question.setEntitiType(EntitiType.QUESTION);
         new_question.setIsDone(Boolean.FALSE);
         new_question.setIsLinkedToGoal(Boolean.TRUE);
-
+        new_question.setSublinked_entities(new HashSet<>());
+        new_question.setSublinked_subgoals(new HashSet<>());
 
         switch (questionPostDTO.getGoalType()) {
             case GOAL:
@@ -359,7 +364,7 @@ public class EntitiService {
                             !new_question.getGroupgoal().getId().equals(parentOfSubgoal(subgoal)))
                         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Parent subgoal is not in the same group!");
 
-                    new_question.setSublinked_subgoals(Set.of(subgoal));
+                    new_question.setSublinked_subgoals(new HashSet<>(Set.of(subgoal)));
                     new_question.setCreator(subgoal.getCreator());
                     new_question.setIsLinkedToGoal(Boolean.FALSE);
                     questionRepository.save(new_question);
@@ -382,6 +387,8 @@ public class EntitiService {
         new_routine.setIsDone(Boolean.FALSE);
         new_routine.setExtension_count(0L);
         new_routine.setIsLinkedToGoal(Boolean.TRUE);
+        new_routine.setSublinked_entities(new HashSet<>());
+        new_routine.setSublinked_subgoals(new HashSet<>());
 
         switch (routinePostDTO.getGoalType()) {
             case GOAL:
@@ -407,7 +414,6 @@ public class EntitiService {
                         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Parent entity is not in the same group!");
 
                     new_routine.setCreator(entiti.getCreator());
-                    new_routine.setSublinked_entities(Set.of(entiti));
                     new_routine.setIsLinkedToGoal(Boolean.FALSE);
                     Routine saved_routine = routineRepository.save(new_routine);
                     entiti.getSublinked_entities().add(saved_routine);
@@ -421,7 +427,7 @@ public class EntitiService {
                             !new_routine.getGroupgoal().getId().equals(parentOfSubgoal(subgoal)))
                         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Parent subgoal is not in the same group!");
 
-                    new_routine.setSublinked_subgoals(Set.of(subgoal));
+                    new_routine.setSublinked_subgoals(new HashSet<>(Set.of(subgoal)));
                     new_routine.setCreator(subgoal.getCreator());
                     new_routine.setIsLinkedToGoal(Boolean.FALSE);
                     routineRepository.save(new_routine);

--- a/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/service/GoalService.java
+++ b/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/service/GoalService.java
@@ -86,6 +86,29 @@ public class GoalService {
         return sublinks;
     }
 
+    private Set<EntitiDTOShort> extractLinkedEntities(Goal goal) {
+
+        Set<EntitiDTOShort> sublinks = new HashSet<>();
+
+        sublinks.addAll(
+                goal.getEntities().stream().filter(x -> x.getClass().getSimpleName().equals("Question"))
+                        .filter(Entiti::getIsLinkedToGoal)
+                        .map(x -> entitiShortMapper.mapToDto((Question) x)).collect(Collectors.toSet()));
+        sublinks.addAll(
+                goal.getEntities().stream().filter(x -> x.getClass().getSimpleName().equals("Task"))
+                        .filter(Entiti::getIsLinkedToGoal)
+                        .map(x -> entitiShortMapper.mapToDto((Task) x)).collect(Collectors.toSet()));
+        sublinks.addAll(
+                goal.getEntities().stream().filter(x -> x.getClass().getSimpleName().equals("Routine"))
+                        .filter(Entiti::getIsLinkedToGoal)
+                        .map(x -> entitiShortMapper.mapToDto((Routine) x)).collect(Collectors.toSet()));
+        sublinks.addAll(
+                goal.getEntities().stream().filter(x -> x.getClass().getSimpleName().equals("Reflection"))
+                        .filter(Entiti::getIsLinkedToGoal)
+                        .map(x -> entitiShortMapper.mapToDto((Reflection) x)).collect(Collectors.toSet()));
+        return sublinks;
+    }
+
     /********************** SEARCH BEGINS *********************************/
     public List<GoalDTOShort> searchGoalsExact(String query, Optional<Long> user_id) {
         if (user_id.isPresent()) {
@@ -175,7 +198,7 @@ public class GoalService {
         GoalGetDTO goalGetDTO = goalGetMapper.mapToDto(goal_from_db_opt.get());
         goalGetDTO.setUser_id(goal_from_db_opt.get().getCreator().getUser_id());
         goalGetDTO.setSubgoals(subgoalShortMapper.mapToDto(goal_from_db_opt.get().getSubgoals().stream().collect(Collectors.toList())).stream().collect(Collectors.toSet()));
-        goalGetDTO.setEntities(extractEntities(goal_from_db_opt.get()));
+        goalGetDTO.setLinkedEntities(extractLinkedEntities(goal_from_db_opt.get()));
         return goalGetDTO;
     }
 

--- a/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/service/GroupGoalService.java
+++ b/application/backend/src/main/java/cmpe451/group12/beabee/goalspace/service/GroupGoalService.java
@@ -13,10 +13,7 @@ import cmpe451.group12.beabee.goalspace.dto.goals.*;
 import cmpe451.group12.beabee.goalspace.enums.GoalType;
 import cmpe451.group12.beabee.goalspace.mapper.entities.EntitiShortMapper;
 import cmpe451.group12.beabee.goalspace.mapper.goals.*;
-import cmpe451.group12.beabee.goalspace.model.entities.Question;
-import cmpe451.group12.beabee.goalspace.model.entities.Reflection;
-import cmpe451.group12.beabee.goalspace.model.entities.Routine;
-import cmpe451.group12.beabee.goalspace.model.entities.Task;
+import cmpe451.group12.beabee.goalspace.model.entities.*;
 import cmpe451.group12.beabee.goalspace.model.goals.Goal;
 import cmpe451.group12.beabee.goalspace.model.goals.GroupGoal;
 import cmpe451.group12.beabee.goalspace.model.goals.Subgoal;
@@ -82,6 +79,29 @@ public class GroupGoalService
         return sublinks;
     }
 
+    private Set<EntitiDTOShort> extractLinkedEntities(GroupGoal groupGoal){
+
+        Set<EntitiDTOShort> sublinks = new HashSet<>();
+
+        sublinks.addAll(
+                groupGoal.getEntities().stream().filter(x -> x.getClass().getSimpleName().equals("Question"))
+                        .filter(Entiti::getIsLinkedToGoal)
+                        .map(x -> entitiShortMapper.mapToDto((Question) x)).collect(Collectors.toSet()));
+        sublinks.addAll(
+                groupGoal.getEntities().stream().filter(x -> x.getClass().getSimpleName().equals("Task"))
+                        .filter(Entiti::getIsLinkedToGoal)
+                        .map(x -> entitiShortMapper.mapToDto((Task) x)).collect(Collectors.toSet()));
+        sublinks.addAll(
+                groupGoal.getEntities().stream().filter(x -> x.getClass().getSimpleName().equals("Routine"))
+                        .filter(Entiti::getIsLinkedToGoal)
+                        .map(x -> entitiShortMapper.mapToDto((Routine) x)).collect(Collectors.toSet()));
+        sublinks.addAll(
+                groupGoal.getEntities().stream().filter(x -> x.getClass().getSimpleName().equals("Reflection"))
+                        .filter(Entiti::getIsLinkedToGoal)
+                        .map(x -> entitiShortMapper.mapToDto((Reflection) x)).collect(Collectors.toSet()));
+        return sublinks;
+    }
+
     public GroupGoalGetDto getAGroupgoal(Long groupgoal_id) {
         GroupGoal groupGoal = groupGoalRepository.findById(groupgoal_id).orElseThrow(
                 () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Group goal not found!")
@@ -89,7 +109,7 @@ public class GroupGoalService
         GroupGoalGetDto groupGoalGetDto = groupGoalGetMapper.mapToDto(groupGoal);
         groupGoalGetDto.setUser_id(groupGoal.getCreator().getUser_id());
         groupGoalGetDto.setSubgoals(new HashSet<>(subgoalShortMapper.mapToDto(new ArrayList<>(groupGoal.getSubgoals()))));
-        groupGoalGetDto.setEntities(extractEntities(groupGoal));
+        groupGoalGetDto.setLinkedEntities(extractLinkedEntities(groupGoal));
         groupGoalGetDto.setTags(groupGoal.getTags().stream().map(Tag::getName).collect(Collectors.toSet()));
         //groupGoalGetDto.setMembers(userCredentialsGetMapper.mapToDto(groupGoal.getMembers().stream().map(x->{x.setPassword("***"); return x;}).collect(Collectors.toList())).stream().collect(Collectors.toSet()));
         return groupGoalGetDto;

--- a/application/backend/src/test/java/cmpe451/group12/beabee/goalspace/service/GroupGoalServiceTest.java
+++ b/application/backend/src/test/java/cmpe451/group12/beabee/goalspace/service/GroupGoalServiceTest.java
@@ -7,6 +7,7 @@ import cmpe451.group12.beabee.common.repository.UserRepository;
 import cmpe451.group12.beabee.common.util.UUIDShortener;
 import cmpe451.group12.beabee.goalspace.Repository.goals.GroupGoalRepository;
 import cmpe451.group12.beabee.goalspace.Repository.goals.SubgoalRepository;
+import cmpe451.group12.beabee.goalspace.Repository.goals.TagRepository;
 import cmpe451.group12.beabee.goalspace.dto.goals.GroupGoalDTOShort;
 import cmpe451.group12.beabee.goalspace.dto.goals.GroupGoalGetDto;
 import cmpe451.group12.beabee.goalspace.dto.goals.GroupGoalPostDTO;
@@ -15,6 +16,7 @@ import cmpe451.group12.beabee.goalspace.mapper.entities.EntitiShortMapper;
 import cmpe451.group12.beabee.goalspace.mapper.goals.*;
 import cmpe451.group12.beabee.goalspace.model.goals.GroupGoal;
 import cmpe451.group12.beabee.goalspace.model.goals.Subgoal;
+import cmpe451.group12.beabee.goalspace.model.goals.Tag;
 import cmpe451.group12.beabee.login.mapper.UserCredentialsGetMapper;
 import org.junit.Assert;
 import org.junit.Before;
@@ -46,6 +48,9 @@ public class GroupGoalServiceTest
     UUIDShortener uuidShortener;
     SubgoalGetMapper subgoalGetMapper;
 
+    TagRepository tagRepository;
+
+
     @Before
     public void setup()
     {
@@ -62,9 +67,11 @@ public class GroupGoalServiceTest
         activityStreamService = Mockito.mock(ActivityStreamService.class);
         uuidShortener = Mockito.mock(UUIDShortener.class);
         subgoalGetMapper = Mockito.mock(SubgoalGetMapper.class);
+
+        tagRepository = Mockito.mock(TagRepository.class);
         groupGoalService = new GroupGoalService(groupGoalRepository, subgoalRepository, groupGoalPostMapper,
                 subgoalPostMapper, subgoalShortMapper, groupGoalGetMapper, groupGoalShortMapper, userRepository, entitiShortMapper,
-                userCredentialsGetMapper, activityStreamService, uuidShortener, subgoalGetMapper);
+                userCredentialsGetMapper, activityStreamService, uuidShortener, subgoalGetMapper, tagRepository);
     }
 
     private Users getRandomUser()


### PR DESCRIPTION
- With this update, users can link their entities directly to their parent goal, and remove this link as well.
- Now Goals, return only entities that are linked to them.
- To get all entities, use `/v2/entities/goal/{goal_id}` and `/v2/entities/groupgoal/{groupgoal_id}` endpoints with GET request.
- Old calls to the api should work as expected, but we may need to check if anyone used entitiesField in Goal or Group Goal Get DTOs.
Implements requests made in issue #523